### PR TITLE
Removed dot at end of output private_zone_name

### DIFF
--- a/vpc/outputs-zones.tf
+++ b/vpc/outputs-zones.tf
@@ -1,5 +1,5 @@
 output "private_zone_name" {
-  value = "${aws_route53_zone.internal_zone.name}"
+  value = "${local.route53_internal_domain}"
 }
 
 output "private_zone_id" {

--- a/vpc/zones.tf
+++ b/vpc/zones.tf
@@ -5,8 +5,11 @@ locals {
 
 # Private internal zone for easier lookups
 resource "aws_route53_zone" "internal_zone" {
-  name   = "${local.route53_internal_domain}"
-  vpc_id = "${module.vpc.vpc_id}"
+  name = "${local.route53_internal_domain}"
+
+  vpc {
+    vpc_id = "${module.vpc.vpc_id}"
+  }
 }
 
 data "aws_route53_zone" "public_hosted_zone" {


### PR DESCRIPTION
Output private_zone_name had a dot at the end, have removed the dot, if you had anything using this output will likely result in a rebuild ie ec2-instances. 

The route53 zone has not been changed just the output and cleared a warning on aws_route53_zone entry.
