### PR TITLE
Added rule to common ssh bastion in security group which allows ingre…

### DIFF
--- a/security-groups/ssh-bastion-in.tf
+++ b/security-groups/ssh-bastion-in.tf
@@ -33,3 +33,13 @@ resource "aws_security_group_rule" "alt_ssh_bastion_in" {
   cidr_blocks       = [ "${values(data.terraform_remote_state.vpc.bastion_vpc_public_cidr)}" ]
   description       = "TF - alt_ssh_bastion_in"
 }
+
+resource "aws_security_group_rule" "ssh_eng_jenkins_in" {
+  security_group_id = "${aws_security_group.ssh_bastion_in.id}"
+  type              = "ingress"
+  protocol          = "tcp"
+  from_port         = "22"
+  to_port           = "22"
+  cidr_blocks       = [ "${data.terraform_remote_state.vpc.eng_vpc_cidr}" ]
+  description       = "TF - ssh_eng_jenkins_in"
+}


### PR DESCRIPTION
…ss on port 22 from the Engineering VPC Cidr.

This overly permissive rule is to enable Ansible operations from the Jenkins Agents.
A tighter rule wasn't considered necessary at this stage.

Closes #89 