### PR TITLE
Update alarms for triggering scale up and down of ecs clusters. Bug i…

### DIFF
--- a/ecs-cluster/data.tf
+++ b/ecs-cluster/data.tf
@@ -26,7 +26,7 @@ data "aws_caller_identity" "current" {}
 # Search for ami id
 data "aws_ami" "ecs_ami" {
   most_recent = true
-
+owners           = ["amazon"]
   # Amazon Linux 2 optimised ECS instance
   filter {
     name   = "name"

--- a/ecs-cluster/main.tf
+++ b/ecs-cluster/main.tf
@@ -5,7 +5,7 @@ terraform {
 
 provider "aws" {
   region  = "${var.region}"
-  version = "~> 1.60"
+  version = "~> 2.4.0"
 }
 
 provider "template" {

--- a/ecs-cluster/variables.tf
+++ b/ecs-cluster/variables.tf
@@ -52,12 +52,22 @@ variable "node_min_count" {
 }
 
 variable "ecs_scale_up_cpu_threshold" {
-  description = "Avg CPU Util above which to add more EC2 resource to the cluster within the boundaries set"
-  default     = "70"
+  description = "Avg CPU reservation util above which to add more EC2 resource to the cluster within the boundaries set"
+  default     = "50"
 }
 
 variable "ecs_scale_down_cpu_threshold" {
-  description = "Avg CPU Util below which to add more EC2 resource to the cluster within the boundaries set"
+  description = "Avg CPU reservation util below which to remove EC2 resource to the cluster within the boundaries set"
+  default     = "40"
+}
+
+variable "ecs_scale_up_mem_threshold" {
+  description = "Avg Memory reservation util above which to add more EC2 resource to the cluster within the boundaries set"
+  default     = "50"
+}
+
+variable "ecs_scale_down_mem_threshold" {
+  description = "Avg Memory reservation util below which to remove EC2 resource to the cluster within the boundaries set"
   default     = "40"
 }
 


### PR DESCRIPTION
…n multi metric alarm handling required update to aws provider version, which in turn required a new required field setting on the ami search

closes #135 