### PR TITLE
Remove workarounds for prod and pre-prod certs after terraform import

### DIFF
--- a/vpc/zones.tf
+++ b/vpc/zones.tf
@@ -47,8 +47,6 @@ resource "aws_route53_record" "delegation_record" {
 }
 
 resource "aws_acm_certificate" "cert" {
-  # TODO once/if public certs are migrated to terraform, prod and pre-prod certs should be managed by TF - this will require imports
-  count             = "${var.environment_name != "delius-prod" && var.environment_name != "delius-pre-prod" ? 1 : 0}"
   domain_name       = "*.${local.strategic_public_domain}"
   validation_method = "DNS"
   tags              = "${merge(var.tags, map("Name", "${local.strategic_public_domain}"))}"


### PR DESCRIPTION
These have now been imported into the Terraform. For pre-prod:
```
[terragrunt] 2019/11/14 14:11:53 Running command: terraform import -var-file=/home/tools/data/env_configs/common-prod/common.tfvars -var-file=/home/tools/data/env_configs/delius-pre-prod/delius-pre-prod.tfvars aws_acm_certificate.cert arn:aws:acm:eu-west-2:010587221707:certificate/407d7a71-46ce-4c6f-8e91-8a5aaec1ad59
aws_acm_certificate.cert: Importing from ID "arn:aws:acm:eu-west-2:010587221707:certificate/407d7a71-46ce-4c6f-8e91-8a5aaec1ad59"...
aws_acm_certificate.cert: Import complete!
  Imported aws_acm_certificate (ID: arn:aws:acm:eu-west-2:010587221707:certificate/407d7a71-46ce-4c6f-8e91-8a5aaec1ad59)
aws_acm_certificate.cert: Refreshing state... (ID: arn:aws:acm:eu-west-2:010587221707:cert...e/407d7a71-46ce-4c6f-8e91-8a5aaec1ad59)

Import successful!

The resources that were imported are shown above. These resources are now in
your Terraform state and will henceforth be managed by Terraform.



[terragrunt] 2019/11/14 14:19:30 Running command: terraform import -var-file=/home/tools/data/env_configs/common-prod/common.tfvars -var-file=/home/tools/data/env_configs/delius-pre-prod/delius-pre-prod.tfvars aws_route53_record.cert_validation Z2HN42YS4OOSPY__e83545e3d1cfcf6948fda30d9e77ca54.pre-prod.probation.service.justice.gov.uk._CNAME_
aws_route53_record.cert_validation: Importing from ID "Z2HN42YS4OOSPY__e83545e3d1cfcf6948fda30d9e77ca54.pre-prod.probation.service.justice.gov.uk._CNAME_"...
aws_route53_record.cert_validation: Import complete!
  Imported aws_route53_record (ID: Z2HN42YS4OOSPY__e83545e3d1cfcf6948fda30d9e77ca54.pre-prod.probation.service.justice.gov.uk._CNAME_)
aws_route53_record.cert_validation: Refreshing state... (ID: Z2HN42YS4OOSPY__e83545e3d1cfcf6948fda30...obation.service.justice.gov.uk._CNAME_)

Import successful!

The resources that were imported are shown above. These resources are now in
your Terraform state and will henceforth be managed by Terraform.
```