### PR TITLE
ALS-2957 Remove unused cloudstor plugin and update default ECS instance type

### DIFF
--- a/ecs-cluster/data.tf
+++ b/ecs-cluster/data.tf
@@ -73,7 +73,6 @@ data "template_file" "ecs_host_userdata_template" {
     region                   = var.region
     efs_sg                   = aws_security_group.ecs_efs_sg.id
     log_group_name           = "${var.environment_name}/shared-ecs-cluster"
-    cloudstor_plugin_version = var.cloudstor_plugin_version
   }
 }
 

--- a/ecs-cluster/templates/ec2/ecs-host-userdata.tpl
+++ b/ecs-cluster/templates/ec2/ecs-host-userdata.tpl
@@ -18,7 +18,6 @@ curl --location https://github.com/aws-observability/aws-otel-java-instrumentati
 # Install any docker plugins
 # Volume plugin for providing EBS/EFS docker volumes
 docker plugin install rexray/efs REXRAY_PREEMPT=true EFS_REGION=${region} EFS_SECURITYGROUPS=${efs_sg} --grant-all-permissions
-docker plugin install --alias cloudstor:aws --grant-all-permissions ${cloudstor_plugin_version} CLOUD_PLATFORM=AWS AWS_REGION=${region} EFS_SUPPORTED=0 DEBUG=1
 
 # Set any ECS agent configuration options
 echo "ECS_CLUSTER=${ecs_cluster_name}" >> /etc/ecs/ecs.config

--- a/ecs-cluster/variables.tf
+++ b/ecs-cluster/variables.tf
@@ -31,11 +31,9 @@ variable "project_name_abbreviated" {
   description = "Shortened environment name"
 }
 
-# Note that to use cloudsto volume plugin, nitro based ECS instances can't be used atm
-# This means cannot use t3, m5, c5 or r5 instance types until plugin supports new volume names used on nitro instances
 variable "ecs_instance_type" {
   description = "EC2 instance type for ECS Hosts"
-  default     = "t2.medium"
+  default     = "m5.large"
 }
 
 variable "node_max_count" {
@@ -72,9 +70,3 @@ variable "ecs_cluster_namespace_name" {
   description = "Private namespace domain name value"
   default     = "ecs.cluster"
 }
-
-variable "cloudstor_plugin_version" {
-  description = "Docker cloudstor ebs volume plugin version"
-  default     = "docker4x/cloudstor:18.09.2-ce-aws1"
-}
-


### PR DESCRIPTION
 to enable deployment of ECS tasks with higher cpu/memory requirements (e.g. Delius WebLogic)